### PR TITLE
Dev

### DIFF
--- a/lib/qdrant-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/qdrant-docker-image-ecr-deployment-cdk-stack.ts
@@ -11,6 +11,7 @@ export class QdrantDockerImageEcrDeploymentCdkStack extends cdk.Stack {
         const ecrRepository = new ecr.Repository(this, `${props.appName}-${props.environment}-DockerImageEcrRepository`, {
             repositoryName: props.repositoryName,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
+            autoDeleteImages: true,
             encryption: ecr.RepositoryEncryption.AES_256
         });
 

--- a/lib/qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -18,6 +18,7 @@ export class QdrantDockerImageEcrDeploymentCdkStack extends cdk.Stack {
         const ecrRepository = new ecr.Repository(this, `${props.appName}-${props.environment}-DockerImageEcrRepository`, {
             repositoryName: props.repositoryName,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
+            autoDeleteImages: true,
             encryption: ecr.RepositoryEncryption.KMS,
             encryptionKey: kmsKey,
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "qdrant-docker-image-ecr-deployment-cdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qdrant-docker-image-ecr-deployment-cdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "aws-cdk-lib": "2.113.0",
-        "cdk-ecr-deployment": "^2.5.37",
+        "cdk-ecr-deployment": "^2.5.38",
         "constructs": "^10.3.0",
         "dotenv": "^16.3.1",
         "source-map-support": "^0.5.21"
@@ -1897,9 +1897,9 @@
       ]
     },
     "node_modules/cdk-ecr-deployment": {
-      "version": "2.5.37",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.37.tgz",
-      "integrity": "sha512-PARACtsEszYn46Jdv5RcLBeetnS4pind29JUVuzHkVoDFpfEy4x6oJQHmslkxfotwoJ8GhWGcABS/i9671W7Pg==",
+      "version": "2.5.38",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.38.tgz",
+      "integrity": "sha512-qZBr1SOEaHJOHEb/bKDm6caUCDCBkGlFZjcHAOoXDiV+Cl4jMgzTcVX4M+nze4yO8RCsdOCl8ZbiYK6CjP8qzQ==",
       "bundleDependencies": [
         "got",
         "hpagent"
@@ -1949,7 +1949,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request/node_modules/@types/node": {
-      "version": "20.10.1",
+      "version": "20.10.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1970,7 +1970,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv/node_modules/@types/node": {
-      "version": "20.10.1",
+      "version": "20.10.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1986,7 +1986,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike/node_modules/@types/node": {
-      "version": "20.10.1",
+      "version": "20.10.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdrant-docker-image-ecr-deployment-cdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "bin": {
     "qdrant-docker-image-ecr-deployment-cdk": "bin/qdrant-docker-image-ecr-deployment-cdk.js"
   },
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.113.0",
-    "cdk-ecr-deployment": "^2.5.37",
+    "cdk-ecr-deployment": "^2.5.38",
     "constructs": "^10.3.0",
     "dotenv": "^16.3.1",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
## type:
Enhancement, Refactoring

___
## description:
This PR introduces several changes:
- The `autoDeleteImages` property has been added to the ECR repositories in both `qdrant-docker-image-ecr-deployment-cdk-stack.ts` and `qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts` files. This property is set to true, enabling automatic deletion of images.
- The version of the application has been updated from 0.2.0 to 0.3.0 in both `package.json` and `package-lock.json` files.
- The version of the `cdk-ecr-deployment` dependency has been updated from 2.5.37 to 2.5.38 in both `package.json` and `package-lock.json` files.
- Other minor updates in `package-lock.json` include the update of the `@types/node` version from 20.10.1 to 20.10.2 in several dependencies.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `lib/qdrant-docker-image-ecr-deployment-cdk-stack.ts`: Added the `autoDeleteImages` property to the ECR repository and set it to true.
- `lib/qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts`: Added the `autoDeleteImages` property to the ECR repository and set it to true.
- `package.json`: Updated the application version from 0.2.0 to 0.3.0 and the `cdk-ecr-deployment` dependency version from 2.5.37 to 2.5.38.
- `package-lock.json`: Updated the application version, the `cdk-ecr-deployment` dependency version, and the `@types/node` version in several dependencies.
</details>
