### PR TITLE
Add checkEnvVariables

### DIFF
--- a/bin/qdrant-docker-image-ecr-deployment-cdk.ts
+++ b/bin/qdrant-docker-image-ecr-deployment-cdk.ts
@@ -11,12 +11,29 @@ const app = new cdk.App();
 const { CDK_DEFAULT_ACCOUNT: account, CDK_DEFAULT_REGION: region } = process.env;
 
 const cdkRegions = process.env.CDK_DEPLOY_REGIONS?.split(',') ?? [region]; // Parsing comma separated list of regions
-const environments = process.env.ENVIRONMENTS?.split(',') ?? ['dev']; // Parsing comma separated list of environments
+const deployEnvironments = process.env.ENVIRONMENTS?.split(',') ?? ['dev']; // Parsing comma separated list of environments
 
 const DEFAULT_IMAGE_VERSION = 'latest';
 
+/*
+ * Check if the environment variables are set
+ * @param args - Environment variables to check
+ * @throws Error if any of the environment variables is not set
+ * @returns void
+ * */
+function checkEnvVariables(...args: string[]) {
+    args.forEach((arg) => {
+        if (!process.env[arg]) {
+            throw new Error(`Environment variable ${arg} is not set yet. Please set it in .env file.`);
+        }
+    });
+}
+
+// check if the environment variables are set
+checkEnvVariables('ECR_REPOSITORY_NAME', 'APP_NAME', 'IMAGE_VERSION');
+
 for (const cdkRegion of cdkRegions) {
-    for (const environment of environments) {
+    for (const environment of deployEnvironments) {
         new QdrantDockerImageEcrDeploymentCdkStack(app, `QdrantDockerImageEcrDeploymentCdkStack-${cdkRegion}-${environment}`, {
             env: {
                 account,


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces a function to check if certain environment variables are set before the deployment script runs. This is an enhancement to the existing deployment script, ensuring that necessary environment variables are present before the deployment process begins. If any of the required environment variables are not set, an error is thrown.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/qdrant-docker-image-ecr-deployment-cdk.ts`: A function named 'checkEnvVariables' has been added. This function accepts an array of strings (representing environment variable names) and checks if these variables are set in the process environment. If any of the variables are not set, it throws an error. The function is then called with 'ECR_REPOSITORY_NAME', 'APP_NAME', and 'IMAGE_VERSION' as arguments to ensure these environment variables are set before the deployment process begins. Additionally, the variable 'environments' has been renamed to 'deployEnvironments' for clarity.
</details>
