### PR TITLE
Only check ECR_REPOSITORY_NAME and APP_NAME

### DIFF
--- a/bin/qdrant-docker-image-ecr-deployment-cdk.ts
+++ b/bin/qdrant-docker-image-ecr-deployment-cdk.ts
@@ -30,7 +30,7 @@ function checkEnvVariables(...args: string[]) {
 }
 
 // check if the environment variables are set
-checkEnvVariables('ECR_REPOSITORY_NAME', 'APP_NAME', 'IMAGE_VERSION');
+checkEnvVariables('ECR_REPOSITORY_NAME', 'APP_NAME');
 
 for (const cdkRegion of cdkRegions) {
     for (const environment of deployEnvironments) {
@@ -42,8 +42,8 @@ for (const cdkRegion of cdkRegions) {
             tags: {
                 environment,
             },
-            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` ?? 'qdrant-docker-image-ecr-deployment-cdk',
-            appName: process.env.APP_NAME ?? 'qdrant-vectordatabase',
+            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}`,
+            appName: process.env.APP_NAME,
             imageVersion: process.env.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
             environment: environment
         });


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR includes changes to the environment variable checks and default values handling in the `bin/qdrant-docker-image-ecr-deployment-cdk.ts` file. The main changes are:
- The `IMAGE_VERSION` environment variable is no longer checked at the start of the script.
- The default values for `repositoryName` and `appName` have been removed. They are now expected to be always provided through environment variables.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/qdrant-docker-image-ecr-deployment-cdk.ts`: The `checkEnvVariables` function no longer checks for `IMAGE_VERSION`. The default values for `repositoryName` and `appName` have been removed, making `ECR_REPOSITORY_NAME` and `APP_NAME` mandatory.
</details>
