### PR TITLE
Only run the pipeline for main branches and pr to dev branch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - dev
-      - stg
-      - main
 
 jobs:
   deploy:
@@ -108,7 +106,6 @@ jobs:
         continue-on-error: false
 
       - name: Deploy to AWS using CDK
-        if: github.event_name == 'push' || !(github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stg' || github.ref == 'refs/heads/main')
         run: npx cdk deploy --require-approval never --all
         env:
           CDK_DEPLOY_REGIONS: ${{ secrets.CDK_DEPLOY_REGIONS }}


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR modifies the GitHub Actions workflow configuration to restrict the pipeline triggers and deployment conditions. The changes include:
- The pipeline will now only be triggered for 'push' events on 'main', 'stg', and 'dev' branches, and 'pull_request' events on the 'dev' branch. Previously, it was also triggered for 'pull_request' events on 'stg' and 'main' branches.
- The condition for deploying to AWS using CDK has been simplified. Previously, it was executed if the event was a 'push' or if the branch was not 'dev', 'stg', or 'main'. Now, this condition has been removed, meaning the deployment will run unconditionally within the workflow.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/release.yml`: The changes in the 'release.yml' file include the removal of 'stg' and 'main' from the 'pull_request' trigger branches, and the removal of the condition for the 'Deploy to AWS using CDK' job.
</details>
