### PR TITLE
v1.7.2

### DIFF
--- a/bin/qdrant-docker-image-ecr-deployment-cdk.ts
+++ b/bin/qdrant-docker-image-ecr-deployment-cdk.ts
@@ -25,7 +25,7 @@ const DEFAULT_IMAGE_VERSION = 'latest';
 function checkEnvVariables(...args: string[]) {
     const missingVariables = args.filter(arg => !process.env[arg]);
     if (missingVariables.length > 0) {
-        throw new Error(`The following environment variables are not set yet: ${missingVariables}. Please set them in .env file or pipeline environments.`);
+        throw new Error(`The following environment variables are not set yet: ${missingVariables.join(', ')}. Please set them in .env file or pipeline environments.`);
     }
 };
 

--- a/lib/qdrant-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/qdrant-docker-image-ecr-deployment-cdk-stack.ts
@@ -23,5 +23,11 @@ export class QdrantDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             src: new ecrDeploy.DockerImageName('qdrant/qdrant:latest'),
             dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion}`),
         });
+
+        // print out ecrRepository arn
+        new cdk.CfnOutput(this, `${props.appName}-${props.environment}-ECRRepositoryArn`, {
+            value: ecrRepository.repositoryArn,
+            exportName: `${props.appName}-${props.environment}-ECRRepositoryArn`,
+        });
     }
 }

--- a/lib/qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -31,5 +31,11 @@ export class QdrantDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             src: new ecrDeploy.DockerImageName('qdrant/qdrant:latest'),
             dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion}`),
         });
+
+        // print out ecrRepository arn
+        new cdk.CfnOutput(this, `${props.appName}-${props.environment}-ECRRepositoryArn`, {
+            value: ecrRepository.repositoryArn,
+            exportName: `${props.appName}-${props.environment}-ECRRepositoryArn`,
+        });
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qdrant-docker-image-ecr-deployment-cdk",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qdrant-docker-image-ecr-deployment-cdk",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "dependencies": {
         "aws-cdk-lib": "2.114.1",
         "cdk-ecr-deployment": "^2.5.40",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qdrant-docker-image-ecr-deployment-cdk",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "bin": {
     "qdrant-docker-image-ecr-deployment-cdk": "bin/qdrant-docker-image-ecr-deployment-cdk.js"
   },


### PR DESCRIPTION
## Type
Enhancement

___
## Description
This PR introduces two main enhancements:
- Improved error handling by joining the missing environment variables into a single string for the error message.
- Added a new feature to print out the ECR repository ARN after the Docker image ECR deployment.

___
## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>qdrant-docker-image-ecr-deployment-cdk.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        bin/qdrant-docker-image-ecr-deployment-cdk.ts<br><br>
        <strong>Improved the error message when environment variables are <br>missing. The missing variables are now joined into a single <br>string.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/qdrant-docker-image-ecr-deployment-cdk/pull/20/files#diff-8f2b118551cd38bf092d142f2837e38ab515d6a288662cce8225a013d72f821b"> +1/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>qdrant-docker-image-ecr-deployment-cdk-stack.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        lib/qdrant-docker-image-ecr-deployment-cdk-stack.ts<br><br>
        <strong>Added a new feature to print out the ECR repository ARN <br>after the Docker image ECR deployment.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/qdrant-docker-image-ecr-deployment-cdk/pull/20/files#diff-23d498561c46f6f2b765aafff4c0634f2f109b2e27c8fc69c0f12091448773ae"> +6/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        lib/qdrant-docker-image-ecr-kms-deployment-cdk-stack.ts<br><br>
        <strong>Added a new feature to print out the ECR repository ARN <br>after the Docker image ECR deployment.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/qdrant-docker-image-ecr-deployment-cdk/pull/20/files#diff-fd5fcc2d12b9288fc8c650044b7b83aa3c37a2a742c4047078cc82aab2b2c622"> +6/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>